### PR TITLE
move career caption block-fields into careers__list div

### DIFF
--- a/collections/careers.list
+++ b/collections/careers.list
@@ -19,9 +19,6 @@
   <squarespace:block-field id="careers__caption-title" columns="12" lock-layout="true"/>
   <squarespace:block-field id="careers__caption-description" columns="12" lock-layout="true"/>
   <hr class="rule__blue"/>
-<div>
-
-<div class="careers__list">
 
 {.repeated section items}
 


### PR DESCRIPTION
allows sizing to be congruent with mockup